### PR TITLE
feat(#4): Enable `declare(strict_types=1);` and use `PHPStan`

### DIFF
--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -1,0 +1,26 @@
+name: PHP CS Fixer
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run PHP CS Fixer
+        run: composer cs:check

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,26 @@
+name: PHPStan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run PHPStan
+        run: composer phpstan:analyze

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
+
+###> phpstan/phpstan ###
+phpstan.neon
+###< phpstan/phpstan ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,8 +10,10 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
+        'declare_strict_types' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.phpactor.json
+++ b/.phpactor.json
@@ -6,5 +6,6 @@
         "/var/cache/**/*",
         "/vendor/composer/**/*"
     ],
-    "language_server_php_cs_fixer.enabled": true
+    "language_server_php_cs_fixer.enabled": true,
+    "language_server_phpstan.enabled": true
 }

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "make:entity": "php bin/console make:entity",
         "make:migration": "php bin/console make:migration",
         "exec:migration": "php bin/console doctrine:migrations:migrate",
-        "phpstan:analyze": "vendor/bin/phpstan analyze src tests",
+        "phpstan:analyze": "vendor/bin/phpstan analyze src",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "make:entity": "php bin/console make:entity",
         "make:migration": "php bin/console make:migration",
         "exec:migration": "php bin/console doctrine:migrations:migrate",
+        "phpstan:analyze": "vendor/bin/phpstan analyze src tests",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "make:entity": "php bin/console make:entity",
         "make:migration": "php bin/console make:migration",
         "exec:migration": "php bin/console doctrine:migrations:migrate",
-        "phpstan:analyze": "vendor/bin/phpstan analyze src tests",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"

--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",
+        "phpstan/phpstan": "^2.1",
         "symfony/maker-bundle": "^1.66"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "628322f53bf34cc1650bc1c8c9ad9d10",
+    "content-hash": "65d6ff1a1eda0408c9dc2d5307f73a92",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -6320,6 +6320,59 @@
                 }
             ],
             "time": "2026-02-20T16:13:53+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.40",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
+                "reference": "9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-23T15:04:35+00:00"
         },
         {
             "name": "react/cache",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 6
+    paths:
+        - src/
+        - tests/

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -2,4 +2,3 @@ parameters:
     level: 6
     paths:
         - src/
-        - tests/

--- a/src/Http/Listeners/JsonExceptionListener.php
+++ b/src/Http/Listeners/JsonExceptionListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Listeners;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;

--- a/src/Http/Listeners/JsonRequestListener.php
+++ b/src/Http/Listeners/JsonRequestListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Listeners;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Shared/Commands/Command.php
+++ b/src/Shared/Commands/Command.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Shared\Commands;
 
 use Symfony\Component\Uid\Uuid;

--- a/src/Shared/Commands/CommandHandler.php
+++ b/src/Shared/Commands/CommandHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Shared\Commands;
 
 interface CommandHandler

--- a/src/Shared/Http/BaseController.php
+++ b/src/Shared/Http/BaseController.php
@@ -11,7 +11,7 @@ abstract class BaseController extends AbstractController
 {
     protected function noContent(): JsonResponse
     {
-        return $this->json(null, Success::NO_CONTENT);
+        return $this->json(null, Success::NO_CONTENT->value);
     }
 
     protected function created(mixed $created, ?string $location = null): JsonResponse

--- a/src/Shared/Http/BaseController.php
+++ b/src/Shared/Http/BaseController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Shared\Http;
 
 use Saboohy\HttpStatus\Client;

--- a/src/Shared/Queries/Query.php
+++ b/src/Shared/Queries/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Shared\Queries;
 
 abstract readonly class Query

--- a/src/Shared/Queries/QueryHandler.php
+++ b/src/Shared/Queries/QueryHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Shared\Queries;
 
 interface QueryHandler

--- a/src/User/Commands/CreateNewUserCommand.php
+++ b/src/User/Commands/CreateNewUserCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Commands;
 
 use App\Shared\Commands\Command;

--- a/src/User/Commands/CreateNewUserCommandHandler.php
+++ b/src/User/Commands/CreateNewUserCommandHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Commands;
 
 use App\Shared\Commands\Command;

--- a/src/User/Controller/UserController.php
+++ b/src/User/Controller/UserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Controller;
 
 use App\Shared\Http\BaseController;

--- a/src/User/Embeddables/Password.php
+++ b/src/User/Embeddables/Password.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Embeddables;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/User/Entity/User.php
+++ b/src/User/Entity/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Entity;
 
 use App\User\Embeddables\Password;

--- a/src/User/Entity/User.php
+++ b/src/User/Entity/User.php
@@ -14,6 +14,7 @@ class User
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    /** @phpstan-ignore property.unusedType */
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]

--- a/src/User/Exceptions/UserAlreadyExistsException.php
+++ b/src/User/Exceptions/UserAlreadyExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Exceptions;
 
 final class UserAlreadyExistsException extends \DomainException

--- a/src/User/Inputs/CreateUserInput.php
+++ b/src/User/Inputs/CreateUserInput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Inputs;
 
 use App\User\Embeddables\Password;

--- a/src/User/Outputs/UserOutput.php
+++ b/src/User/Outputs/UserOutput.php
@@ -20,8 +20,8 @@ final readonly class UserOutput
     ) {
     }
 
-    public static function fromUser(User $src): self
+    public static function fromUser(User $user): self
     {
-        return new self($src->getId(), $src->getName(), $src->getEmail(), $src->getCreatedAt());
+        return new self($user->getId(), $user->getName(), $user->getEmail(), $user->getCreatedAt());
     }
 }

--- a/src/User/Outputs/UserOutput.php
+++ b/src/User/Outputs/UserOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Outputs;
 
 use App\User\Entity\User;

--- a/src/User/Queries/GetUserByEmail/GetUserByEmailQuery.php
+++ b/src/User/Queries/GetUserByEmail/GetUserByEmailQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Queries\GetUserByEmail;
 
 use App\Shared\Queries\Query;

--- a/src/User/Queries/GetUserByEmail/GetUserByEmailQueryHandler.php
+++ b/src/User/Queries/GetUserByEmail/GetUserByEmailQueryHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Queries\GetUserByEmail;
 
 use App\Shared\Queries\Query;

--- a/src/User/Queries/GetUserByID/GetUserByIDQuery.php
+++ b/src/User/Queries/GetUserByID/GetUserByIDQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Queries\GetUserByID;
 
 use App\Shared\Queries\Query;

--- a/src/User/Queries/GetUserByID/GetUserByIDQueryHandler.php
+++ b/src/User/Queries/GetUserByID/GetUserByIDQueryHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Queries\GetUserByID;
 
 use App\Shared\Queries\Query;

--- a/src/User/Repository/UserRepository.php
+++ b/src/User/Repository/UserRepository.php
@@ -4,7 +4,6 @@ namespace App\User\Repository;
 
 use App\User\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -13,8 +12,7 @@ use Doctrine\Persistence\ManagerRegistry;
 class UserRepository extends ServiceEntityRepository
 {
     public function __construct(
-        private ManagerRegistry $registry,
-        private Connection $connection,
+        ManagerRegistry $registry,
     ) {
         parent::__construct($registry, User::class);
     }

--- a/src/User/Repository/UserRepository.php
+++ b/src/User/Repository/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\User\Repository;
 
 use App\User\Entity\User;

--- a/symfony.lock
+++ b/symfony.lock
@@ -60,6 +60,18 @@
             "config/routes/nelmio_api_doc.yaml"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        },
+        "files": [
+            "phpstan.dist.neon"
+        ]
+    },
     "symfony/console": {
         "version": "8.0",
         "recipe": {


### PR DESCRIPTION
## Description

Enable `declare(strict_types=1);` in the `php-actor` and enable `phpstan` to allow code analysis 

## Related Issue

Closes #4

## Checklist

- [x] This PR is linked to an issue (bug or feature)
- [x] The issue ID is referenced above
- [x] Code builds successfully
